### PR TITLE
Feat/inventory quantities

### DIFF
--- a/src/Services/AttributesService.php
+++ b/src/Services/AttributesService.php
@@ -31,11 +31,11 @@ class AttributesService
     static array $baseFields = [
         "descriptionHtml",
         "title",
-        "options",//array
+        "options", //array
         "productType",
         "vendor",
-        "tags",//array
-        "status",// "ACTIVE" "ARCHIVED" or "DRAFT"
+        "tags", //array
+        "status", // "ACTIVE" "ARCHIVED" or "DRAFT"
     ];
 
     static array $fieldTypes = [
@@ -47,20 +47,21 @@ class AttributesService
     ];
 
     static array $variantFields = [
-        "cost",//productVariantInput.inventoryItem
-        "tracked",//productVariantInput.inventoryItem
+        "cost", //productVariantInput.inventoryItem
+        "tracked", //productVariantInput.inventoryItem
         "price",
         "compareAtPrice",
         "taxCode",
         "taxable",
         "sku",
         "barcode",
-        "continueSellingOutOfStock",//inventoryPolicy "CONTINUE" or "DENY"
+        "continueSellingOutOfStock", //inventoryPolicy "CONTINUE" or "DENY"
         "weight",
-        "weightUnit",//needs to be "POUNDS" "OUNCES" "KILOGRAMS" or "GRAMS"
+        "weightUnit", //needs to be "POUNDS" "OUNCES" "KILOGRAMS" or "GRAMS"
         "requiresShipping",
-        "imageSrc",//variants can only have one image
+        "imageSrc", //variants can only have one image
         "title",
+        "stock",
     ];
 
     public function getRemoteFields(Graphql $client): array
@@ -162,7 +163,7 @@ class AttributesService
                 }
                 foreach ($classes as $allowedClass) {
                     $allowedClass = ClassDefinition::getByName($allowedClass["classes"]);
-                    if(!in_array($allowedClass, $checkedClasses)){
+                    if (!in_array($allowedClass, $checkedClasses)) {
                         $this->getFieldDefinitionsRecursive($allowedClass, $attributes, $prefix . $field->getName() . ".", array_merge([$allowedClass], $checkedClasses));
                     }
                 }

--- a/src/Services/ShopifyHelpers/ShopifyGraphqlHelperService.php
+++ b/src/Services/ShopifyHelpers/ShopifyGraphqlHelperService.php
@@ -18,6 +18,8 @@ class ShopifyGraphqlHelperService
     private static $GET_VARIANTS_QUERY = '/shopify-queries/variants-query.graphql';
     private static $SET_METAFIELD_QUERY = '/shopify-queries/metafield-set-value.graphql';
     private static $GET_STORE_LOCATION_QUERY = '/shopify-queries/store-location-query.graphql';
+    private static $BULK_GET_VARIANT_STOCK_BY_ID = '/shopify-queries/variant-stock-by-id.graphql';
+    private static $UPDATE_VARIANT_STOCK = '/shopify-queries/bulk-update-quantities.graphql';
 
     public static function buildCreateProductsQuery($remoteFile)
     {
@@ -124,5 +126,15 @@ class ShopifyGraphqlHelperService
     {
         $storeLocationQuery = file_get_contents(dirname(__FILE__) . self::$GET_STORE_LOCATION_QUERY);
         return $storeLocationQuery;
+    }
+
+    public static function buildVariantsStockByIdQuery()
+    {
+        return file_get_contents(dirname(__FILE__) . self::$BULK_GET_VARIANT_STOCK_BY_ID);
+    }
+
+    public static function buildUpdateVariantsStockQuery()
+    {
+        return file_get_contents(dirname(__FILE__) . self::$UPDATE_VARIANT_STOCK);
     }
 }

--- a/src/Services/ShopifyHelpers/ShopifyGraphqlHelperService.php
+++ b/src/Services/ShopifyHelpers/ShopifyGraphqlHelperService.php
@@ -17,6 +17,7 @@ class ShopifyGraphqlHelperService
     private static $UPDATE_VARIANTS_QUERY = '/shopify-queries/update-product-variants.graphql';
     private static $GET_VARIANTS_QUERY = '/shopify-queries/variants-query.graphql';
     private static $SET_METAFIELD_QUERY = '/shopify-queries/metafield-set-value.graphql';
+    private static $GET_STORE_LOCATION_QUERY = '/shopify-queries/store-location-query.graphql';
 
     public static function buildCreateProductsQuery($remoteFile)
     {
@@ -117,5 +118,11 @@ class ShopifyGraphqlHelperService
     {
         $updateVariantsQuery = file_get_contents(dirname(__FILE__) . self::$SET_METAFIELD_QUERY);
         return self::bulkwrap($updateVariantsQuery, $remoteFile);
+    }
+
+    public static function buildStoreLocationQuery()
+    {
+        $storeLocationQuery = file_get_contents(dirname(__FILE__) . self::$GET_STORE_LOCATION_QUERY);
+        return $storeLocationQuery;
     }
 }

--- a/src/Services/ShopifyHelpers/ShopifyQueryService.php
+++ b/src/Services/ShopifyHelpers/ShopifyQueryService.php
@@ -272,6 +272,7 @@ class ShopifyQueryService
     {
         $variantsByIdQuery = ShopifyGraphqlHelperService::buildVariantsStockByIdQuery();
         $variantsUpdateInventoryQuery = ShopifyGraphqlHelperService::buildUpdateVariantsStockQuery();
+        $results = [];
         $variantsQueryInput = [];
         $variantsInventoryInput = [];
         $changes = [];
@@ -298,6 +299,7 @@ class ShopifyQueryService
                     ]
                 ];
                 $response = $this->runQuery($variantsUpdateInventoryQuery, $variantsInventoryInput);
+                $results[] = $response;
                 unset($variantsQueryInput);
             }
         }
@@ -319,9 +321,10 @@ class ShopifyQueryService
                 ]
             ];
             $response = $this->runQuery($variantsUpdateInventoryQuery, $variantsInventoryInput);
+            $results[] = $response;
             unset($variantsQueryInput);
         }
-        //https://shopify.dev/docs/api/usage/rate-limits#maximum-input-array-size-limit
+        return $results;
     }
 
     public function getPrimaryStoreLocationId()

--- a/src/Services/ShopifyHelpers/ShopifyQueryService.php
+++ b/src/Services/ShopifyHelpers/ShopifyQueryService.php
@@ -268,6 +268,13 @@ class ShopifyQueryService
         return $resultFiles;
     }
 
+    public function getPrimaryStoreLocationId()
+    {
+        $query = ShopifyGraphqlHelperService::buildStoreLocationQuery();
+        $result = $this->runQuery($query);
+        return $result["data"]["location"]["id"];
+    }
+
     private function makeFile($content)
     {
         $file = tmpfile();

--- a/src/Services/ShopifyHelpers/ShopifyQueryService.php
+++ b/src/Services/ShopifyHelpers/ShopifyQueryService.php
@@ -13,6 +13,8 @@ use TorqIT\StoreSyndicatorBundle\Services\ShopifyHelpers\ShopifyGraphqlHelperSer
  */
 class ShopifyQueryService
 {
+    const MAX_QUERY_OBJS = 250;
+
     private Graphql $graphql;
     public function __construct(
         ShopifyAuthenticator $abstractAuthenticator
@@ -271,7 +273,7 @@ class ShopifyQueryService
         foreach ($inputArray as $id => $quantity) {
             $variantsQueryInput["ids"][] = $id;
             $count++;
-            if ($count >= 250) {
+            if ($count >= self::MAX_QUERY_OBJS) {
                 $count = 0;
                 $changes = [];
                 $response = $this->runQuery($variantsByIdQuery, $variantsQueryInput);

--- a/src/Services/ShopifyHelpers/shopify-queries/bulk-update-quantities.graphql
+++ b/src/Services/ShopifyHelpers/shopify-queries/bulk-update-quantities.graphql
@@ -1,0 +1,8 @@
+mutation inventoryAdjustQuantities($input: InventoryAdjustQuantitiesInput!) {
+  inventoryAdjustQuantities(input: $input) {
+    userErrors {
+      field
+      message
+    }
+  }
+}

--- a/src/Services/ShopifyHelpers/shopify-queries/store-location-query.graphql
+++ b/src/Services/ShopifyHelpers/shopify-queries/store-location-query.graphql
@@ -1,0 +1,5 @@
+query {
+  location {
+    id
+  }
+}

--- a/src/Services/ShopifyHelpers/shopify-queries/variant-stock-by-id.graphql
+++ b/src/Services/ShopifyHelpers/shopify-queries/variant-stock-by-id.graphql
@@ -1,0 +1,17 @@
+query variantStockById($ids: [ID!]!) {
+  nodes(ids: $ids) {
+    ... on ProductVariant {
+      id
+      inventoryItem {
+        id
+        inventoryLevels(first: 1) {
+          edges {
+            node {
+              available
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/Services/Stores/ShopifyStore.php
+++ b/src/Services/Stores/ShopifyStore.php
@@ -211,7 +211,6 @@ class ShopifyStore extends BaseStore
         if (isset($fields['base variant']['stock'])) {
             $graphQLInput["inventoryQuantities"]["availableQuantity"] = $fields['base variant']['stock'][0];
             $graphQLInput["inventoryQuantities"]["locationId"] = $this->storeLocationId;
-            continue;
         }
         if (!isset($graphQLInput["options"])) {
             $graphQLInput["options"][] = $child->getKey();
@@ -256,6 +255,9 @@ class ShopifyStore extends BaseStore
     private function processBaseVariantData($fields, &$thisVariantArray)
     {
         foreach ($fields as $field => $value) {
+            if ($field == "stock") { // special cases
+                continue;
+            }
             if ($field == 'weight' || $field == 'cost' || $field == 'price') { //wants this as a non-string wrapped number
                 $value[0] = (float)$value[0];
             }

--- a/src/Services/Stores/ShopifyStore.php
+++ b/src/Services/Stores/ShopifyStore.php
@@ -37,6 +37,7 @@ class ShopifyStore extends BaseStore
     private array $updateImageMap;
     private array $metafieldTypeDefinitions;
     private array $storeLocationId;
+    private array $updateStock;
     // private array $productMetafieldsMapping;
     //private array $variantMetafieldsMapping;
 
@@ -243,6 +244,9 @@ class ShopifyStore extends BaseStore
 
         $thisVariantArray = [];
         $this->processBaseVariantData($fields['base variant'], $thisVariantArray);
+        if (isset($fields['base variant']['stock'])) {
+            $this->updateStock[$remoteId] = $fields['base variant']['stock'][0];
+        }
         if (!isset($thisVariantArray["options"])) {
             $thisVariantArray["options"][] = $child->getKey();
         }
@@ -404,6 +408,13 @@ class ShopifyStore extends BaseStore
                 }
             } catch (Exception $e) {
                 $commitResults->addError("error during metafield setting in commit: " . $e->getMessage() . "\nFile: " . $e->getFile() . "\nLine: " . $e->getLine() . "\nTrace: " . $e->getTraceAsString());
+            }
+        }
+        if ($this->updateStock) {
+            try {
+                $this->shopifyQueryService->updateStock($this->updateStock, $this->storeLocationId);
+            } catch (Exception $e) {
+                $commitResults->addError("error during stock update in commit: " . $e->getMessage() . "\nFile: " . $e->getFile() . "\nLine: " . $e->getLine() . "\nTrace: " . $e->getTraceAsString());
             }
         }
         $this->config->save();

--- a/src/Services/Stores/ShopifyStore.php
+++ b/src/Services/Stores/ShopifyStore.php
@@ -36,6 +36,7 @@ class ShopifyStore extends BaseStore
     private array $metafieldSetArrays;
     private array $updateImageMap;
     private array $metafieldTypeDefinitions;
+    private array $storeLocationId;
     // private array $productMetafieldsMapping;
     //private array $variantMetafieldsMapping;
 
@@ -63,6 +64,7 @@ class ShopifyStore extends BaseStore
         $authenticator = ShopifyAuthenticator::getAuthenticatorFromConfig($config);
         $this->shopifyQueryService = new ShopifyQueryService($authenticator);
         $this->metafieldTypeDefinitions = $this->shopifyQueryService->queryMetafieldDefinitions();
+        $this->storeLocationId = $this->shopifyQueryService->getPrimaryStoreLocationId();
 
         $this->updateProductArrays = [];
         $this->createProductArrays = [];
@@ -178,12 +180,12 @@ class ShopifyStore extends BaseStore
     private function processBaseProductData($fields, &$graphQLInput)
     {
         foreach ($fields as $field => $value) {
-            if($field == "status"){
+            if ($field == "status") {
                 $value[0] = strtoupper($value[0]);
-                if(!in_array($value[0], ["ACTIVE", "ARCHIVED", "DRAFT"])){
+                if (!in_array($value[0], ["ACTIVE", "ARCHIVED", "DRAFT"])) {
                     throw new Exception("invalid status value $value[0] not one of ACTIVE ARCHIVED or DRAFT");
                 }
-            }elseif($field == 'tags'){
+            } elseif ($field == 'tags') {
                 $graphQLInput[$field] = $value;
                 continue;
             }
@@ -206,6 +208,11 @@ class ShopifyStore extends BaseStore
         }
 
         $this->processBaseVariantData($fields['base variant'], $graphQLInput);
+        if (isset($fields['base variant']['stock'])) {
+            $graphQLInput["inventoryQuantities"]["availableQuantity"] = $fields['base variant']['stock'][0];
+            $graphQLInput["inventoryQuantities"]["locationId"] = $this->storeLocationId;
+            continue;
+        }
         if (!isset($graphQLInput["options"])) {
             $graphQLInput["options"][] = $child->getKey();
         }
@@ -246,28 +253,29 @@ class ShopifyStore extends BaseStore
         $this->updateVariantsArrays[] = $thisVariantArray;
     }
 
-    private function processBaseVariantData($fields, &$thisVariantArray){
+    private function processBaseVariantData($fields, &$thisVariantArray)
+    {
         foreach ($fields as $field => $value) {
             if ($field == 'weight' || $field == 'cost' || $field == 'price') { //wants this as a non-string wrapped number
                 $value[0] = (float)$value[0];
             }
-            if($field == 'tracked'){
+            if ($field == 'tracked') {
                 $value[0] = $value[0] == "true";
             }
-            if($field == 'cost' || $field == 'tracked'){
+            if ($field == 'cost' || $field == 'tracked') {
                 $thisVariantArray['inventoryItem'][$field] = $value[0];
                 continue;
-            }elseif($field == 'continueSellingOutOfStock'){
-                $thisVariantArray['inventoryPolicy'] = $value[0]? "CONTINUE": "DENY";
+            } elseif ($field == 'continueSellingOutOfStock') {
+                $thisVariantArray['inventoryPolicy'] = $value[0] ? "CONTINUE" : "DENY";
                 continue;
-            }elseif($field == 'weightUnit'){
+            } elseif ($field == 'weightUnit') {
                 $value[0] = strtoupper($value[0]);
-                if(!in_array($value[0], ["POUNDS", "OUNCES", "KILOGRAMS", "GRAMS"])){
+                if (!in_array($value[0], ["POUNDS", "OUNCES", "KILOGRAMS", "GRAMS"])) {
                     throw new Exception("invalid weightUnit value $value[0] not one of POUNDS OUNCES KILOGRAMS or GRAMS");
                 }
-            }elseif($field == 'imageSrc'){
+            } elseif ($field == 'imageSrc') {
                 $value[0] = $value[0]->getFrontendFullPath();
-            }elseif($field == 'title'){
+            } elseif ($field == 'title') {
                 $thisVariantArray["options"][] = $value[0];
                 continue;
             }

--- a/src/Services/Stores/ShopifyStore.php
+++ b/src/Services/Stores/ShopifyStore.php
@@ -36,7 +36,7 @@ class ShopifyStore extends BaseStore
     private array $metafieldSetArrays;
     private array $updateImageMap;
     private array $metafieldTypeDefinitions;
-    private array $storeLocationId;
+    private string $storeLocationId;
     private array $updateStock;
     // private array $productMetafieldsMapping;
     //private array $variantMetafieldsMapping;
@@ -72,6 +72,7 @@ class ShopifyStore extends BaseStore
         $this->updateVariantsArrays = [];
         $this->metafieldSetArrays = [];
         $this->updateImageMap = [];
+        $this->updateStock = [];
 
         Db::get()->query('SET SESSION wait_timeout = ' . 28800); //timeout to 8 hours for this session
     }
@@ -210,7 +211,7 @@ class ShopifyStore extends BaseStore
 
         $this->processBaseVariantData($fields['base variant'], $graphQLInput);
         if (isset($fields['base variant']['stock'])) {
-            $graphQLInput["inventoryQuantities"]["availableQuantity"] = $fields['base variant']['stock'][0];
+            $graphQLInput["inventoryQuantities"]["availableQuantity"] = (float)$fields['base variant']['stock'][0];
             $graphQLInput["inventoryQuantities"]["locationId"] = $this->storeLocationId;
         }
         if (!isset($graphQLInput["options"])) {
@@ -412,7 +413,8 @@ class ShopifyStore extends BaseStore
         }
         if ($this->updateStock) {
             try {
-                $this->shopifyQueryService->updateStock($this->updateStock, $this->storeLocationId);
+                $results = $this->shopifyQueryService->updateStock($this->updateStock, $this->storeLocationId);
+                $this->addLogRow("update stock results: ", json_encode($results));
             } catch (Exception $e) {
                 $commitResults->addError("error during stock update in commit: " . $e->getMessage() . "\nFile: " . $e->getFile() . "\nLine: " . $e->getLine() . "\nTrace: " . $e->getTraceAsString());
             }


### PR DESCRIPTION
Resolves TORQ-93

added the 'stock' option that will push a pimcore field into the 'available' and 'on hand' quantities fields on shopify. 

note that this field will only work when a product also has a field mapped to the 'tracked' base variant field set to true.